### PR TITLE
Update some incorrect package names

### DIFF
--- a/dist/defaults.js
+++ b/dist/defaults.js
@@ -36,7 +36,7 @@ class ServerConfiguration {
         try {
             var rootPath;
             try {
-                rootPath = path.dirname(require.resolve("wise-js-api/package.json"));
+                rootPath = path.dirname(require.resolve("WISE_JS_API/package.json"));
             }
             catch (e2) {
                 //if the package can't be resolved it will throw a MODULE_NOT_FOUND error
@@ -47,7 +47,7 @@ class ServerConfiguration {
             //if the user didn't specify a job directory try loading one from the npm configuration
             if (this.configLocation == null || this.configLocation.length == 0) {
                 const conf = npmConf();
-                this.configLocation = conf.get('wise-js-api:job_directory');
+                this.configLocation = conf.get('WISE_JS_API:job_directory');
                 //use the config.json from the jobs directory if available, otherwise look locally
                 if (this.configLocation == null || this.configLocation.length == 0) {
                     const internalConfigPath = path.join(rootPath, "config", "config.json");

--- a/proto/wise_config.proto
+++ b/proto/wise_config.proto
@@ -6,7 +6,7 @@ option csharp_namespace = "WISE_API.NET.Proto";
 
 import "google/protobuf/wrappers.proto";
 
-package wise.confic;
+package wise.api;
 
 /**
  * General server configuration details.
@@ -33,9 +33,6 @@ message ServerConfiguration {
 
     //The directory where sample data is stored for testing purposes
     string exampleDirectory = 7;
-
-    //Settings that are only used by W.I.S.E. Manager
-    ManagerSettings manager_settings = 8;
 
     //Are the W.I.S.E. Manager settings already setup for v2
     google.protobuf.BoolValue already_v2 = 9;

--- a/proto/wise_defaults.proto
+++ b/proto/wise_defaults.proto
@@ -4,7 +4,7 @@ option java_package = "ca.wise.defaults.proto";
 option java_multiple_files = true;
 option csharp_namespace = "WISE_API.NET.Proto";
 
-package wise.defaults;
+package wise.api;
 
 /**
  * Default values for a selection of job inputs.


### PR DESCRIPTION
The package names set in the proto files had been set wrong. Also update the configuration job directory to match the library name.